### PR TITLE
Add missing newline at the end of ComsController file

### DIFF
--- a/src/core/coms/coms.controller.ts
+++ b/src/core/coms/coms.controller.ts
@@ -90,3 +90,4 @@ export class ComsController {
       );
   }
 }
+


### PR DESCRIPTION
Ensure proper formatting by adding a missing newline at the end of the ComsController file.