### PR TITLE
Add sudo to Docker commands for permission issues

### DIFF
--- a/.github/workflows/CICD Microservices.yaml
+++ b/.github/workflows/CICD Microservices.yaml
@@ -49,7 +49,7 @@ jobs:
           cd ${{secrets.PATH_DOCKER_COMPOSE}}
           
           echo "Pulling the latest image for ${{vars.MICROSERVICE_NAME}}..."
-          docker pull ghcr.io/hsm-sanosoft/${{vars.MICROSERVICE_NAME}}:latest
+          sudo docker pull ghcr.io/hsm-sanosoft/${{vars.MICROSERVICE_NAME}}:latest
 
           echo "Restarting ${{vars.MICROSERVICE_NAME}} container..."
-          docker-compose -f docker-compose.prod.yml up -d --no-deps ${{vars.MICROSERVICE_NAME}}
+          sudo docker compose -f docker-compose.prod.yml up -d --no-deps ${{vars.MICROSERVICE_NAME}}


### PR DESCRIPTION
Add `sudo` to the Docker pull and compose commands to ensure proper permissions during execution.