### PR TITLE
Restrict compania field in DetalleDTO to specific values

### DIFF
--- a/src/microservices/has/cob/gdp/transaccion/dto/solicitudPago.dto.ts
+++ b/src/microservices/has/cob/gdp/transaccion/dto/solicitudPago.dto.ts
@@ -60,7 +60,7 @@ class DetalleDTO {
 
   @IsNotEmpty()
   @IsString()
-  compania: string;
+  compania: 'SAS' | 'CSI' | 'TEST';
 
   @IsNotEmpty()
   @IsObject()


### PR DESCRIPTION
Limit the values of the compania field in DetalleDTO to 'SAS', 'CSI', and 'TEST' to ensure data integrity.